### PR TITLE
fix: update exercise title to reflect scaling institutional knowledge

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -20,7 +20,7 @@ jobs:
     name: Start Exercise
     uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.7.1
     with:
-      exercise-title: "Democratize Team Knowledge Using Copilot Spaces"
+      exercise-title: "Scale institutional knowledge using Copilot Spaces"
       intro-message: "Use Copilot Spaces to share, update, and add content for a central knowledge base"
 
   post_next_step_content:

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -66,4 +66,4 @@ jobs:
     uses: skills/exercise-toolkit/.github/workflows/finish-exercise.yml@v0.7.1
     with:
       issue-url: ${{ needs.find_exercise.outputs.issue-url }}
-      exercise-title: "Democratize Team Knowledge Using Copilot Spaces"
+      exercise-title: "Scale institutional knowledge using Copilot Spaces"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Democratize team knowledge using Copilot Spaces
+# Scale institutional knowledge using Copilot Spaces
 
-Learn how Copilot Spaces can democratize team knowledge and streamline organizational processes.
+Learn how Copilot Spaces can scale institutional knowledge and streamline organizational processes.
 
 ## What are Copilot Spaces?
 


### PR DESCRIPTION
This pull request updates the messaging throughout the repository to focus on "scaling institutional knowledge" rather than "democratizing team knowledge" when describing Copilot Spaces. The changes ensure consistent terminology in both documentation and workflow configuration.

Content and messaging updates:

* Updated the exercise title and intro message in `.github/workflows/0-start-exercise.yml` to use "Scale institutional knowledge using Copilot Spaces" instead of "Democratize Team Knowledge Using Copilot Spaces."
* Changed the exercise title in `.github/workflows/3-last-step.yml` to match the new phrasing.
* Revised the main heading and description in `README.md` to reflect the new focus on scaling institutional knowledge.