### PR TITLE
Fix image source for attach files in 3-step.md

### DIFF
--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -35,7 +35,7 @@ _Use the following prompt in a new Copilot Space conversation:_
   `.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml`
 
      <img width="30%" height="30%" alt="Attach" src="https://github.com/user-attachments/assets/2a447ff9-76d7-462f-9292-4663c8dc0fc9" />
-     <img width="30%" height="30%" alt="Attach files" src="https://github.com/user-attachments/assets/6ac6e33d-b333-424f-b431-e3feb7022b841" />
+     <img width="30%" height="30%" alt="Attach files" src="https://github.com/user-attachments/assets/6ac6e33d-b333-424f-b431-e3feb7022b84" />
 
      <img width="30%" height="30%" alt="Attach issue template conversation" src="https://github.com/user-attachments/assets/5fc71905-ede6-45cb-bcfa-93d2797160b2" />
 


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

This image reference had an extra character `1` at the end. Probably a typo? It was 1 character too long, and while the UI is smart enough to delete that extra `1` - our automation to check the links failed

Page not found (current) -  https://github.com/user-attachments/assets/6ac6e33d-b333-424f-b431-e3feb7022b841
Fixed - https://github.com/user-attachments/assets/6ac6e33d-b333-424f-b431-e3feb7022b84

The current version used as an image fixes itself and removes the extra `1` when clicked through the Github UI. Click the button below and notice the `1` is not present in the URL

 <img width="30%" height="30%" alt="Attach files" src="https://github.com/user-attachments/assets/6ac6e33d-b333-424f-b431-e3feb7022b841" />


### Changes
<!-- Describe the changes this pull request introduces. -->


<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: https://github.com/skills/exercise-manager/issues/57

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
