### PR TITLE
Add GitHub.copilot-chat to devcontainer extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "vscode": {
       "extensions": [
         "GitHub.copilot",
+        "GitHub.copilot-chat",
         "ms-python.python",
         "ms-python.debugpy",
         "ms-vscode.live-server",


### PR DESCRIPTION
Adds GitHub.copilot-chat extension to the VS Code devcontainer extensions list.