### PR TITLE
Trigger step checks on merge to main to avoid Actions approval

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -18,7 +18,7 @@ GitHub Copilot Spaces enables teams to centralize and democratize organizational
 To get started, you need access to Copilot Spaces and a GitHub Copilot plan with premium request units. Each prompt in a Space counts toward your usage quota, so be mindful of your plan's limits. For more details, see [GitHub Copilot plans](https://docs.github.com/en/copilot/get-started/plans#comparing-copilot-plans) and [Copilot Requests](https://docs.github.com/en/copilot/concepts/billing/copilot-requests).
 
 > [!IMPORTANT]
-> If you are using a Copilot free plan or are concerned with impacting usage based billing, use "**Auto**". These models do not consume premium request units. For more information, see [GitHub Copilot plans](https://docs.github.com/en/copilot/get-started/plans#comparing-copilot-plans, [Usage Based Billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals), and [Usage Based Billing for Enterprises and Organizations](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises).
+> If you are using a Copilot free plan or are concerned with impacting usage based billing, use "**Auto**". These models do not consume premium request units. For more information, see [GitHub Copilot plans](https://docs.github.com/en/copilot/get-started/plans#comparing-copilot-plans), [Usage Based Billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals), and [Usage Based Billing for Enterprises and Organizations](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises).
 
 > [!NOTE]
 > **Optional:** This exercise now advances automatically when you merge your pull

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -20,10 +20,12 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
 > [!IMPORTANT]
 > If you are using a Copilot free plan or are concerned with impacting usage based billing, use "**Auto**". These models do not consume premium request units. For more information, see [GitHub Copilot plans](https://docs.github.com/en/copilot/get-started/plans#comparing-copilot-plans, [Usage Based Billing for individuals](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-individuals), and [Usage Based Billing for Enterprises and Organizations](https://docs.github.com/en/copilot/concepts/billing/usage-based-billing-for-organizations-and-enterprises).
 
-> [!IMPORTANT]
-> Before starting this GitHub Skills exercise make sure
-> **Settings** --> **Actions** --> **General** (part way down) shown in the following image
-> "**Require approval for first-time contributors who are new to GitHub**"
+> [!NOTE]
+> **Optional:** This exercise now advances automatically when you merge your pull
+> request, so you do not need to change any approval settings to progress.
+> If you prefer, you can still review **Settings** --> **Actions** --> **General**
+> (part way down) --> "**Require approval for first-time contributors who are new to GitHub**"
+> shown in the following image, but it is not required for this exercise.
 
 <img width="50%" alt="copilot-spaces-create-space" src="../images/settings-actions-general-approvals.png" />
 
@@ -149,5 +151,7 @@ You can copy or open the link in a new tab to see the newly created issue
 - Make sure you have access to GitHub Copilot Spaces and that your repository is added as a source
 - The repository should be publicly accessible for Copilot to index it
 - Repository indexing can take seconds to minutes depending on size
+- **Conversation clears when you press Send?** Reload the page and try again, or use the **Retry** button. This is usually a transient Copilot Spaces UI issue
+- If the message keeps disappearing, confirm you have access to Copilot Spaces and, on a free plan, select the **Auto** or a **0x** model before sending
 
 </details>

--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -151,7 +151,7 @@ You can copy or open the link in a new tab to see the newly created issue
 - Make sure you have access to GitHub Copilot Spaces and that your repository is added as a source
 - The repository should be publicly accessible for Copilot to index it
 - Repository indexing can take seconds to minutes depending on size
-- **Conversation clears when you press Send?** Reload the page and try again, or use the **Retry** button. This is usually a transient Copilot Spaces UI issue
-- If the message keeps disappearing, confirm you have access to Copilot Spaces and, on a free plan, select the **Auto** or a **0x** model before sending
+- **Conversation clears when you press Send?** Reload the page and try again, or use the **Retry** button. This is usually a transient Copilot Spaces UI issue.
+- If the message keeps disappearing, confirm you have access to Copilot Spaces and, on a free plan, select **Auto** or another model that does not consume premium request units before sending.
 
 </details>

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -153,5 +153,6 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
 - **Issue not attaching?** Make sure you're using the exact format `@{{full_repo_name}}/issues/#` where `#` is your issue number
 - **Copilot Cloud Agent not working?** Ensure you have the necessary permissions to create pull requests in your repository
 - **Pull request creation failed?** The issue must be properly attached before the Copilot Cloud Agent can work on it
+- **Step didn't advance after merging?** The check runs automatically when the pull request is merged into `main`. Give it a moment, then open the [Actions tab](https://github.com/{{full_repo_name}}/actions) to confirm the **Step 2** run completed. No manual approval is required
 
 </details>

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -176,5 +176,6 @@ In the same Copilot Space conversation do the following:
 - Consider adding templates, checklists, or clarifying existing processes
 - Common improvements include: role clarification, communication protocols, decision-making frameworks
 - Even small improvements like adding examples or clarifying steps can be valuable
+- **Step didn't complete after merging?** The check runs automatically when the pull request is merged into `main`. Give it a moment, then open the [Actions tab](https://github.com/{{full_repo_name}}/actions) to confirm the **Step 3** run completed. No manual approval is required
 
 </details>

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -1,11 +1,9 @@
 name: Step 2
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
     paths:
       - "docs/**"
 

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -1,11 +1,9 @@
 name: Step 3 # Last step of the exercise
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
     paths:
       - "docs/**"
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If the exercise isn't ready in 20 seconds, please check the [Actions](../../acti
 
 - If the page shows a failed job, please submit an issue. Nice, you found a bug! 🐛
 
+- Steps advance automatically when you merge your pull request into `main`; no manual workflow approval is required. If a step seems delayed, check the [Actions](../../actions) tab to confirm the run completed.
+
 </details>
 
 ---


### PR DESCRIPTION
## Why

Learners reported the exercise gets stuck after Step 2 and never advances: Mona posts no feedback and Step 3 stays locked even after the pull request is merged (issues #59 and #64).

The root cause is the Actions approval gate. Steps 2 and 3 triggered on `pull_request: closed`, but the exercise pull requests are authored by the Copilot coding agent. GitHub holds workflow runs on bot/first-time-contributor pull requests in "waiting for approval," so the grading job and the "post next step" job never ran when the learner merged.

## What changed

- **Workflows:** switch Step 2 (`2-step.yml`) and Step 3 (`3-last-step.yml`) triggers from `pull_request: closed` to `push` on `main` with `paths: docs/**`, matching the existing Step 0 start workflow. The merge push is performed by the learner (who has write access), so the checks run automatically with no manual approval. As a bonus this fixes a latent bug where a pull request closed *without* merging would have advanced the exercise.
- **Step 1 doc:** the "Require approval for first-time contributors" pre-flight note is reframed from a hard requirement to an optional `[!NOTE]` (kept for now, can be removed later), since progression no longer depends on it.
- **Step 1 troubleshooting:** added guidance for the Copilot Space conversation blanking out on send (issue #67) - reload/Retry and confirm Spaces access / model selection.
- **Step 2, Step 3, README:** clarified that steps advance automatically on merge and to check the Actions tab if a run seems delayed; removed any implication that manual approval is needed.

## Notes for reviewers

Verified that neither Step 2 nor Step 3 uses `github.event.pull_request.*` context or a `merged` guard, so dropping the pull_request event is safe. Grading only inspects `docs/README.md` on disk, which is present on `main` after merge. The Step 1 -> 2 -> 3 enable/disable gating is unchanged, so disabled steps still won't fire on the initial template push. All four workflow YAML files parse cleanly.

Issue #67's deeper Copilot Space UI behavior is a product-side concern; this change only adds learner-facing troubleshooting for it.
