### PR TITLE
Fix step workflows firing on repo clone; polish checks and alt text

### DIFF
--- a/.github/steps/1-step.md
+++ b/.github/steps/1-step.md
@@ -27,7 +27,7 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
 > (part way down) --> "**Require approval for first-time contributors who are new to GitHub**"
 > shown in the following image, but it is not required for this exercise.
 
-<img width="50%" alt="copilot-spaces-create-space" src="../images/settings-actions-general-approvals.png" />
+<img width="50%" alt="GitHub repository Settings, Actions, General page showing the approval requirement option" src="../images/settings-actions-general-approvals.png" />
 
 ### ⌨️ Activity: Create your OctoAcme Project Management Hub Copilot Space
 
@@ -41,7 +41,7 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
 
 1. Click **Create Space**
 
-   <img width="50%" alt="copilot-spaces-create-space" src="../images/copilot-spaces-create-space.png" />
+   <img width="50%" alt="Create Space button in GitHub Copilot Spaces" src="../images/copilot-spaces-create-space.png" />
 
    Add a description:
 
@@ -50,13 +50,13 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
       > for the OctoAcme organization
       > ```
 
-      <img width="50%" alt="copilot-spaces-description" src="../images/copilot-spaces-description.png" />
+      <img width="50%" alt="Adding a description to the Copilot Space" src="../images/copilot-spaces-description.png" />
 
 ### ⌨️ Activity: Add instructions to your Copilot Space
 
 1. In your newly created Copilot Space, look for the **Instructions** box and click in the **Instructions** box
 
-   <img width="50%" alt="copilot-spaces-instructions" src="../images/copilot-spaces-instructions.png" />
+   <img width="50%" alt="Instructions box in a Copilot Space" src="../images/copilot-spaces-instructions.png" />
 
 1. Add the following instructions to provide context about the repository and its purpose
 
@@ -83,13 +83,13 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
 
    It should look something like this when you're done:
 
-   <img width="50%" alt="copilot-spaces-instructions-detail" src="../images/copilot-spaces-instructions-detail.png" />
+   <img width="50%" alt="Copilot Space Instructions box filled in with repository context" src="../images/copilot-spaces-instructions-detail.png" />
 
 1. Click **Save**
 
 ### ⌨️ Activity: Add your cloned repository as a source repository to your Copilot Space
 
-1. In your newly created Copilot Space, look for the <img width="15%" alt="add-sources-button" src="../images/add-sources-button.png" /> button
+1. In your newly created Copilot Space, look for the <img width="15%" alt="Add sources button in a Copilot Space" src="../images/add-sources-button.png" /> button
 1. Click **Add files from repository**
    - Copy and paste your GitHub repository for this exercise called out below.
    - You can also type the name in the search and it will come up as well or copy/paste the name below.
@@ -103,9 +103,9 @@ To get started, you need access to Copilot Spaces and a GitHub Copilot plan with
 1. Select the `docs` and the `.github/ISSUE_TEMPLATE` folders and click **Add**
 1. Verify the repository appears in your sources list
 
-   <img width="30%" alt="add-sources" src="../images/add-sources.png" />
-   <img width="30%" alt="add-sources-repository" src="../images/add-sources-repository.png" />
-   <img width="30%" alt="add-sources-repository-files" src="../images/add-sources-repository-files.png" />
+   <img width="30%" alt="Add sources dialog in a Copilot Space" src="../images/add-sources.png" />
+   <img width="30%" alt="Selecting a repository as a source in a Copilot Space" src="../images/add-sources-repository.png" />
+   <img width="30%" alt="Selecting the docs and issue template folders as Copilot Space sources" src="../images/add-sources-repository-files.png" />
 
 ### ⌨️ Activity: Create an issue in the repository for a README for OctoAcme Project Management Docs
 
@@ -128,12 +128,12 @@ You can then add this issue to your repository by clicking the **Create** button
 > [!NOTE]
 > If an issue is not created, click the **Retry** button shown below
 
-<img width="215" alt="Retry button to regenerate an issue in Copilot Space" src="../images/retry-copilot-space.png" />
+<img width="215" alt="Retry button to regenerate the issue or pull request in Copilot Space" src="../images/retry-copilot-space.png" />
 
 <details>
 <summary> 📷 Show screenshot of the issue draft</summary>
 
-<img width="50%" alt="readme-issue-drafted" src="../images/readme-issue-drafted.png" />
+<img width="50%" alt="Draft of the README issue in Copilot Space" src="../images/readme-issue-drafted.png" />
 
 </details>
 You can copy or open the link in a new tab to see the newly created issue
@@ -141,7 +141,7 @@ You can copy or open the link in a new tab to see the newly created issue
 <details>
 <summary> 📷 Show screenshot of the created issue</summary>
 
-<img width="50%" alt="readme-issue-created" src="../images/readme-issue-created.png" />
+<img width="50%" alt="The created README issue shown in the repository" src="../images/readme-issue-created.png" />
 
 </details>
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -96,7 +96,7 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
 
 5. **Allow the Copilot Cloud Agent**: When prompted, select **Allow** to let the Copilot Cloud Agent work on your repository
 
-   <img width="100%" alt="Allow prompt granting the Copilot coding agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
+   <img width="100%" alt="Allow prompt granting the Copilot Cloud Agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
 
 6. **Monitor progress**: You should receive a notification that the Copilot Cloud Agent is working on your pull request.
 

--- a/.github/steps/2-step.md
+++ b/.github/steps/2-step.md
@@ -34,11 +34,11 @@ Proceed to the activities and run the provided prompts in your Copilot Space.
 
    Open your Copilot Space you created in the previous step. https://github.com/copilot/spaces and select **Yours** and select **"OctoAcme Project Management Hub"**
 
-   <img width="50%" alt="copilot-spaces-yours" src="../images/copilot-spaces-yours.png" />
+   <img width="50%" alt="The Yours tab in Copilot Spaces listing your spaces" src="../images/copilot-spaces-yours.png" />
 
 2. Start a new conversation in the Copilot Space and prompt the following:
 
-   <img width="70%" alt="copilot-spaces-conversation-summary" src="../images/copilot-spaces-conversation-summary.png" />
+   <img width="70%" alt="Prompting the Copilot Space to summarize the project management docs" src="../images/copilot-spaces-conversation-summary.png" />
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -51,7 +51,7 @@ Proceed to the activities and run the provided prompts in your Copilot Space.
    <details>
    <summary> 📷 Show screenshot of the conversation output</summary>
 
-   <img width="50%" alt="copilot-spaces-conversation-summary-output" src="../images/copilot-spaces-conversation-summary-output.png" />
+   <img width="50%" alt="Copilot Space conversation output showing the generated process summary" src="../images/copilot-spaces-conversation-summary-output.png" />
 
    </details>
 
@@ -76,7 +76,7 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
 
 4. **Create the pull request**: Now send this prompt to create the pull request:
 
-   <img width="80%" alt="repository-issue-pr-creation" src="../images/repository-issue-pr-creation-step2.png" />
+   <img width="80%" alt="Prompt to create a pull request from the attached README issue in Copilot Space" src="../images/repository-issue-pr-creation-step2.png" />
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -92,11 +92,11 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
 > [!NOTE]
 > If an issue or pull request is not created, click the **Retry** button shown below
 
-<img width="215" alt="Retry button to regenerate an issue or pull request in Copilot Space" src="../images/retry-copilot-space.png" />
+<img width="215" alt="Retry button to regenerate the issue or pull request in Copilot Space" src="../images/retry-copilot-space.png" />
 
 5. **Allow the Copilot Cloud Agent**: When prompted, select **Allow** to let the Copilot Cloud Agent work on your repository
 
-   <img width="100%" alt="copilot-cloud-agent-allow" src="../images/copilot-cloud-agent-allow.png" />
+   <img width="100%" alt="Allow prompt granting the Copilot coding agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
 
 6. **Monitor progress**: You should receive a notification that the Copilot Cloud Agent is working on your pull request.
 
@@ -106,17 +106,17 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
 
    Go to your repository and click **Pull requests** and select the pull request to see the progress:
 
-      <img width="70%" alt="pull-requests" src="../images/pull-requests.png" />
+      <img width="70%" alt="Pull requests tab in the repository showing the open pull request" src="../images/pull-requests.png" />
 
    #### Option 2: Check Agent Sessions in your Copilot Space on the left side under Agent sessions
 
    You can track the progress of the Copilot Cloud Agent and view details on the left side under **Agent sessions**. Click on the session to see details about the tasks being performed by the agent.
 
-      <img width="40%" alt="agent-session-1" src="../images/agent-sessions-1.png" />
+      <img width="40%" alt="Agent sessions panel in the Copilot Space showing the running session" src="../images/agent-sessions-1.png" />
 
    You can get to the pull request that the agent is working on by clicking the link in the session details at the bottom where it says **View pull request**.
 
-      <img width="40%" alt="view-pull-request" src="../images/view-pull-request.png" />
+      <img width="40%" alt="View pull request link in the Copilot Space session details" src="../images/view-pull-request.png" />
 
 7. **Check open pull requests**: We can check pull request status from our **Copilot Space** as well.
 
@@ -126,25 +126,25 @@ In this activity, you will connect the issue you created in Step 1 to your Copil
    > check open pull requests
    > ```
 
-   <img width="40%" alt="check-open-prs" src="../images/check-open-prs-2.png" />
+   <img width="40%" alt="Copilot Space response listing the open pull request" src="../images/check-open-prs-2.png" />
 
    Click the link to the pull request in the Copilot Space to view the PR details and monitor the Copilot Cloud Agent's progress.
 
 > [!NOTE]
-> The Copilot Cloud Agent typically takes 5-15 minutes to complete the work. If you want to track the work that the Copilot Cloud Agent is doing from within the pull request, click **View session** <img width="10%" alt="view-session" src="../images/view-session.png" /> to watch the progress if desired.
+> The Copilot Cloud Agent typically takes 5-15 minutes to complete the work. If you want to track the work that the Copilot Cloud Agent is doing from within the pull request, click **View session** <img width="10%" alt="View session button on the pull request" src="../images/view-session.png" /> to watch the progress if desired.
 
 8. **Review and merge**: Once the pull request is ready:
 
    a. **Submit review**: Leave a comment (optional), click **Approve**, then **Submit review**
 
-      <img width="70%" alt="add-review" src="../images/add-review.png" />
+      <img width="70%" alt="Approving the pull request in the review form" src="../images/add-review.png" />
 
-      <img width="50%" alt="submit-review" src="../images/submit-review.png" />
+      <img width="50%" alt="Submit review button in the pull request review form" src="../images/submit-review.png" />
 
    b. **Merge**: Select **Ready for review**, then **Merge pull request** and **Confirm merge**
 
-      <img width="50%" alt="ready-for-review" src="../images/ready-for-review.png" />
-      <img width="50%" alt="merge-pull-request" src="../images/merge-pull-request.png" />
+      <img width="50%" alt="Marking the pull request as ready for review" src="../images/ready-for-review.png" />
+      <img width="50%" alt="Merge pull request button on the pull request" src="../images/merge-pull-request.png" />
 
 <details>
 <summary>Having trouble? 🤷</summary>

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -23,12 +23,12 @@ Effective process evolution follows a lightweight cycle:
 
 ### ⌨️ Activity: Attach an issue template and create an issue for process improvements
 
-   <img width="50%" alt="copilot-spaces-yours" src="../images/copilot-spaces-yours.png" />
+   <img width="50%" alt="The Yours tab in Copilot Spaces listing your spaces" src="../images/copilot-spaces-yours.png" />
 
-1. Add your files from the repository to the conversation by clicking on <img width="5%" alt="add-files-plus" src="../images/add-files-plus.png" /> and selecting the option to add **Files**:
+1. Add your files from the repository to the conversation by clicking on <img width="5%" alt="Add files plus button in a Copilot Space conversation" src="../images/add-files-plus.png" /> and selecting the option to add **Files**:
 
-   <img width="50%" alt="copilot-spaces-chat-plus" src="../images/copilot-spaces-chat-plus.png" />
-   <img width="30%" alt="add-files" src="../images/add-files.png" />
+   <img width="50%" alt="Plus menu in the Copilot Space conversation showing the Files option" src="../images/copilot-spaces-chat-plus.png" />
+   <img width="30%" alt="Files option in the Copilot Space add sources menu" src="../images/add-files.png" />
 
 1. Select your repository or copy and paste the repository name in the search bar to find it:
 
@@ -36,17 +36,17 @@ Effective process evolution follows a lightweight cycle:
    > {{full_repo_name}}
    > ```
 
-   <img width="40%" alt="add-sources-repository" src="../images/add-sources-repository.png" />
+   <img width="40%" alt="Selecting a repository as a source in a Copilot Space" src="../images/add-sources-repository.png" />
 
 1. Select the issue template to this new Copilot Space conversation.
 
    `.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml`
 
-     <img width="30%" alt="add-issue-template" src="../images/add-issue-template.png" />
+     <img width="30%" alt="Attaching the issue template file to the Copilot Space conversation" src="../images/add-issue-template.png" />
 
 1. Start a new conversation in the Copilot Space and use the following prompt to create an issue that identifies gaps in the project management processes documentation related to personas/roles and outlines needed improvements. Make sure to reference the attached issue template in your prompt.
 
-   <img width="40%" alt="copilot-spaces-chat" src="../images/copilot-spaces-chat.png" />
+   <img width="40%" alt="Copilot Space conversation input box" src="../images/copilot-spaces-chat.png" />
 
   > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
   >
@@ -64,7 +64,7 @@ Effective process evolution follows a lightweight cycle:
    <details>
    <summary> 📷 Show screenshot of the issue draft</summary>
 
-   <img width="50%" alt="personas-roles-issue-draft" src="../images/personas-roles-issue-draft.png" />
+   <img width="50%" alt="Draft of the personas and roles improvement issue in Copilot Space" src="../images/personas-roles-issue-draft.png" />
 
    </details>
    You can copy or open the link in a new tab to see the newly created issue
@@ -72,7 +72,7 @@ Effective process evolution follows a lightweight cycle:
    <details>
    <summary> 📷 Show screenshot of the created issue</summary>
 
-   <img width="50%" alt="personas-roles-issue-created" src="../images/personas-roles-issue-created.png" />
+   <img width="50%" alt="The created personas and roles improvement issue in the repository" src="../images/personas-roles-issue-created.png" />
 
    </details>
 
@@ -100,7 +100,7 @@ In the same Copilot Space conversation do the following:
 
    (Example: if your issue is #4, type `@{{full_repo_name}}/issues/4`)
 
-   <img width="40%" alt="repository-issue-pr-creation" src="../images/repository-issue-pr-creation-step3.png" />
+   <img width="40%" alt="Prompt to create a pull request from the attached personas and roles issue in Copilot Space" src="../images/repository-issue-pr-creation-step3.png" />
 
    > ![Static Badge](https://img.shields.io/badge/-Prompt-text?style=social&logo=github%20copilot)
    >
@@ -117,11 +117,11 @@ In the same Copilot Space conversation do the following:
 > [!NOTE]
 > If an issue or pull request is not created, click the **Retry** button shown below
 
-<img width="215" alt="Retry button to regenerate an issue or pull request in Copilot Space" src="../images/retry-copilot-space.png" />
+<img width="215" alt="Retry button to regenerate the issue or pull request in Copilot Space" src="../images/retry-copilot-space.png" />
 
 4. **Allow the Copilot Cloud Agent**: When prompted, select **Allow** to let the Copilot Cloud Agent work on your repository
 
-   <img width="100%" alt="copilot-cloud-agent-allow" src="../images/copilot-cloud-agent-allow.png" />
+   <img width="100%" alt="Allow prompt granting the Copilot coding agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
 
 5. **Monitor progress**: You should receive a notification that the Copilot Cloud Agent is working on your pull request.
 
@@ -131,17 +131,17 @@ In the same Copilot Space conversation do the following:
 
    Go to your repository and click **Pull requests** and select the pull request to see the progress:
 
-      <img width="70%" alt="pull-requests" src="../images/pull-requests.png" />
+      <img width="70%" alt="Pull requests tab in the repository showing the open pull request" src="../images/pull-requests.png" />
 
    #### Option 2: Check Agent Sessions in your Copilot Space on the left side under Agent sessions
 
    You can track the progress of the Copilot Cloud Agent and view details on the left side under **Agent sessions**. Click on the session to see details about the tasks being performed by the agent.
 
-      <img width="40%" alt="agent-session" src="../images/agent-sessions-2.png" />
+      <img width="40%" alt="Agent sessions panel in the Copilot Space showing session details" src="../images/agent-sessions-2.png" />
 
    You can get to the pull request that the agent is working on by clicking the link in the session details at the bottom where it says **View pull request**.
 
-      <img width="40%" alt="view-pull-request" src="../images/view-pull-request.png" />
+      <img width="40%" alt="View pull request link in the Copilot Space session details" src="../images/view-pull-request.png" />
 
 6. **Check open pull requests**: We can check pull request status from our **Copilot Space** as well.
 
@@ -151,23 +151,23 @@ In the same Copilot Space conversation do the following:
    > check open pull requests
    > ```
 
-   <img width="40%" alt="check-open-prs" src="../images/check-open-prs-3.png" />
+   <img width="40%" alt="Copilot Space response listing the open pull request" src="../images/check-open-prs-3.png" />
 
 > [!NOTE]
-> The Copilot Cloud Agent typically takes 5-15 minutes to complete the work. If you want to track the work that the Copilot Cloud Agent is doing from within the pull request, click **View session** <img width="10%" alt="view-session" src="../images/view-session.png" /> to watch the progress if desired.
+> The Copilot Cloud Agent typically takes 5-15 minutes to complete the work. If you want to track the work that the Copilot Cloud Agent is doing from within the pull request, click **View session** <img width="10%" alt="View session button on the pull request" src="../images/view-session.png" /> to watch the progress if desired.
 
 7. **Review and merge**: Once the pull request is ready:
 
    a. **Submit review**: Leave a comment (optional), click **Approve**, then **Submit review**
 
-      <img width="70%" alt="add-review" src="../images/add-review.png" />
+      <img width="70%" alt="Approving the pull request in the review form" src="../images/add-review.png" />
 
-      <img width="50%" alt="submit-review" src="../images/submit-review.png" />
+      <img width="50%" alt="Submit review button in the pull request review form" src="../images/submit-review.png" />
 
    b. **Merge**: Select **Ready for review**, then **Merge pull request** and **Confirm merge**
 
-      <img width="50%" alt="ready-for-review" src="../images/ready-for-review.png" />
-      <img width="50%" alt="merge-pull-request" src="../images/merge-pull-request.png" />
+      <img width="50%" alt="Marking the pull request as ready for review" src="../images/ready-for-review.png" />
+      <img width="50%" alt="Merge pull request button on the pull request" src="../images/merge-pull-request.png" />
 
 <details>
 <summary>Having trouble? 🤷</summary>

--- a/.github/steps/3-step.md
+++ b/.github/steps/3-step.md
@@ -121,7 +121,7 @@ In the same Copilot Space conversation do the following:
 
 4. **Allow the Copilot Cloud Agent**: When prompted, select **Allow** to let the Copilot Cloud Agent work on your repository
 
-   <img width="100%" alt="Allow prompt granting the Copilot coding agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
+   <img width="100%" alt="Allow prompt granting the Copilot Cloud Agent access to the repository" src="../images/copilot-cloud-agent-allow.png" />
 
 5. **Monitor progress**: You should receive a notification that the Copilot Cloud Agent is working on your pull request.
 

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -18,6 +18,12 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
+    # Skip the initial seeding commit created when a learner generates the repo from the
+    # template. That first push to main also carries docs/**, which would otherwise trigger
+    # this workflow before the exercise issue exists (and before Step 0 can disable it),
+    # producing a failing run. A branch-creation push sets github.event.created == true;
+    # later merges to main do not, so grading still runs when the learner progresses.
+    if: ${{ !github.event.created }}
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.8.1
 
   # This job is optional. We often call it a "grading job". If the step is not graded, remove it.

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - "docs/**"
+      - "docs/README.md"
 
 permissions:
   contents: write
@@ -80,7 +80,7 @@ jobs:
         uses: skills/action-keyphrase-checker@v1.1.0
         with:
           text-file: docs/README.md
-          keyphrase: "roles"
+          keyphrase: "project management"
           case-sensitive: false
 
       - name: Update comment - step results
@@ -96,7 +96,7 @@ jobs:
             results_table:
               - description: "Checked if README.md file exists"
                 passed: ${{ steps.check-file-exists.outcome == 'success' }}
-              - description: "Checked for roles in README.md"
+              - description: "Checked README.md summarizes the project management processes"
                 passed: ${{ steps.check-for-keyphrase.outcome == 'success' }}
 
       # Add more checks as needed

--- a/.github/workflows/2-step.yml
+++ b/.github/workflows/2-step.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           repository: ${{ env.ISSUE_REPOSITORY }}
           issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-author: "github-actions[bot]"
           direction: last
 
       - name: Update comment - checking work

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -26,9 +26,86 @@ jobs:
     if: ${{ !github.event.created }}
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.8.1
 
+  # Grading job: confirms the learner's personas/roles improvement landed in the docs.
+  check_step_work:
+    name: Check step work
+    runs-on: ubuntu-latest
+    needs: [find_exercise]
+    env:
+      ISSUE_REPOSITORY: ${{ github.repository }}
+      ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Get response templates
+        uses: actions/checkout@v5
+        with:
+          repository: skills/exercise-toolkit
+          path: exercise-toolkit
+          ref: v0.8.1
+
+      - name: Find last comment
+        id: find-last-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          repository: ${{ env.ISSUE_REPOSITORY }}
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          direction: last
+
+      - name: Update comment - checking work
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          repository: ${{ env.ISSUE_REPOSITORY }}
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-id: ${{ steps.find-last-comment.outputs.comment-id }}
+          file: exercise-toolkit/markdown-templates/step-feedback/checking-work.md
+          edit-mode: replace
+
+      # START: Check practical exercise
+
+      - name: Check personas/roles doc exists
+        id: check-personas-file
+        continue-on-error: true
+        uses: skills/exercise-toolkit/actions/file-exists@v0.8.1
+        with:
+          file: docs/octoacme-roles-and-personas.md
+
+      - name: Check personas/roles doc describes responsibilities
+        id: check-responsibilities
+        continue-on-error: true
+        uses: skills/action-keyphrase-checker@v1.1.0
+        with:
+          text-file: docs/octoacme-roles-and-personas.md
+          keyphrase: "responsibilities"
+          case-sensitive: false
+
+      - name: Update comment - step results
+        uses: GrantBirki/comment@v2.1.1
+        with:
+          repository: ${{ env.ISSUE_REPOSITORY }}
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-id: ${{ steps.find-last-comment.outputs.comment-id }}
+          edit-mode: replace
+          file: exercise-toolkit/markdown-templates/step-feedback/step-results-table.md
+          vars: |
+            step_number: 3
+            results_table:
+              - description: "Checked personas and roles doc exists"
+                passed: ${{ steps.check-personas-file.outcome == 'success' }}
+              - description: "Checked personas and roles doc describes responsibilities"
+                passed: ${{ steps.check-responsibilities.outcome == 'success' }}
+
+      # END: Check practical exercise
+
+      - name: Fail job if not all checks passed
+        if: contains(steps.*.outcome, 'failure')
+        run: exit 1
+
   post_review_content:
     name: Post review content
-    needs: [find_exercise] # if check_step_work then "needs: [find_exercise, check_step_work]"
+    needs: [find_exercise, check_step_work]
     runs-on: ubuntu-latest
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Get response templates
         uses: actions/checkout@v5
@@ -52,6 +54,7 @@ jobs:
         with:
           repository: ${{ env.ISSUE_REPOSITORY }}
           issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-author: "github-actions[bot]"
           direction: last
 
       - name: Update comment - checking work
@@ -65,21 +68,26 @@ jobs:
 
       # START: Check practical exercise
 
-      - name: Check personas/roles doc exists
-        id: check-personas-file
+      # Grade that the learner actually changed the personas/roles doc in the merged
+      # pull request, rather than only that the file exists (it ships with the starter repo).
+      - name: Check the personas and roles doc was updated in this pull request
+        id: check-personas-updated
         continue-on-error: true
-        uses: skills/exercise-toolkit/actions/file-exists@v0.8.1
-        with:
-          file: docs/octoacme-roles-and-personas.md
-
-      - name: Check personas/roles doc describes responsibilities
-        id: check-responsibilities
-        continue-on-error: true
-        uses: skills/action-keyphrase-checker@v1.1.0
-        with:
-          text-file: docs/octoacme-roles-and-personas.md
-          keyphrase: "responsibilities"
-          case-sensitive: false
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+          TARGET_FILE: docs/octoacme-roles-and-personas.md
+        run: |
+          echo "Comparing $BEFORE_SHA...$AFTER_SHA"
+          changed="$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")"
+          echo "Files changed in this push:"
+          echo "$changed"
+          if echo "$changed" | grep -qx "$TARGET_FILE"; then
+            echo "$TARGET_FILE was updated."
+          else
+            echo "::error::$TARGET_FILE was not updated in this pull request."
+            exit 1
+          fi
 
       - name: Update comment - step results
         uses: GrantBirki/comment@v2.1.1
@@ -92,10 +100,8 @@ jobs:
           vars: |
             step_number: 3
             results_table:
-              - description: "Checked personas and roles doc exists"
-                passed: ${{ steps.check-personas-file.outcome == 'success' }}
-              - description: "Checked personas and roles doc describes responsibilities"
-                passed: ${{ steps.check-responsibilities.outcome == 'success' }}
+              - description: "Checked the personas and roles doc was updated in your pull request"
+                passed: ${{ steps.check-personas-updated.outcome == 'success' }}
 
       # END: Check practical exercise
 

--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -18,6 +18,12 @@ env:
 jobs:
   find_exercise:
     name: Find Exercise Issue
+    # Skip the initial seeding commit created when a learner generates the repo from the
+    # template. That first push to main also carries docs/**, which would otherwise trigger
+    # this workflow before the exercise issue exists (and before Step 0 can disable it),
+    # producing a failing run. A branch-creation push sets github.event.created == true;
+    # later merges to main do not, so grading still runs when the learner progresses.
+    if: ${{ !github.event.created }}
     uses: skills/exercise-toolkit/.github/workflows/find-exercise-issue.yml@v0.8.1
 
   post_review_content:


### PR DESCRIPTION
## Why

When a learner copied this exercise to their own account, the very first "Initial commit" push to `main` triggered the Step 2 and Step 3 workflows before the exercise had even started. Those runs failed (no exercise issue exists yet), leaving red X's on the Actions tab on a fresh clone. Root cause: a recent change switched Step 2/3 to trigger on `push` to `main` (paths `docs/**`), and the starter content already ships `docs/**`, so the repo-seeding commit matched. Step 0's `disable_workflows` job cannot prevent this because it is the same push event (a race, not a sequence).

## What

- **Guard the seeding commit.** `find_exercise` in Step 2 and Step 3 now carries `if: ${{ !github.event.created }}`. The template-seeding commit is a branch-creation push (`created == true`) and is skipped, so all dependent jobs skip and the run is neutral instead of failed. Normal learner merges to `main` are not branch creations, so grading still runs as the exercise progresses.
- **Tighten the Step 2 trigger.** Narrowed the push path filter to `docs/README.md` (a file not present in starter content), so Step 2 no longer even queues a run on clone; it fires only when the learner's README PR merges.
- **Sharper Step 2 check.** Swapped the keyphrase check from the incidental `roles` to `project management`, which is central to the summarization task.
- **Grade the final step.** Added a light `check_step_work` job to Step 3 that verifies the personas/roles doc exists and describes responsibilities, mirroring Step 2 and giving the learner a visible results table.
- **Accessibility.** Rewrote 48 slug-style image `alt` attributes across steps 1-3 into descriptive phrases, and fixed the Step 1 approvals screenshot whose alt incorrectly read `copilot-spaces-create-space`.

## Notes for reviewers

- The enable/disable progression is unchanged and verified: Step 0 -> Step 1 -> Step 2 -> Step 3 -> finish, with names matching each workflow.
- No double-advance: at each merge the next step's workflow is still disabled, and disabled workflows do not trigger.
- The Step 3 grading signals are reliably true after a genuine completion, so this gates progression without false negatives.

## Suggested validation

- Generate a fresh repo from the template and confirm only Step 0 runs; Step 2/3 no longer appear as failures.
- Walk the happy path (create README issue, merge README PR, merge personas PR) and confirm each step advances and the exercise finishes.
