### PR TITLE
Require merged pull request before finishing Step 3

### DIFF
--- a/.github/workflows/3-last-step.yml
+++ b/.github/workflows/3-last-step.yml
@@ -11,6 +11,7 @@ permissions:
   contents: write
   actions: write
   issues: write
+  pull-requests: read
 
 env:
   REVIEW_FILE: ".github/steps/x-review.md"
@@ -68,6 +69,29 @@ jobs:
 
       # START: Check practical exercise
 
+      # Ensure the personas/roles update arrived through a merged pull request rather than a
+      # commit pushed straight to main. Without this guard, any direct commit that touches
+      # docs/** (for example, when the Copilot Cloud Agent commits directly instead of
+      # opening a pull request) would satisfy the file check below and finish the exercise
+      # before the pull request is ever reviewed and merged. Requiring a merged pull request
+      # keeps the intended issue -> pull request -> review -> merge workflow intact.
+      - name: Verify the update arrived via a merged pull request
+        id: check-merged-pr
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.after }}
+        run: |
+          echo "Looking for a merged pull request associated with $HEAD_SHA"
+          merged_prs="$(gh api "repos/${{ github.repository }}/commits/${HEAD_SHA}/pulls" --jq '[.[] | select(.merged_at != null)]')"
+          count="$(echo "$merged_prs" | jq 'length')"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::This change was pushed directly to main. Open a pull request for the personas and roles update and merge it, rather than committing directly to main."
+            exit 1
+          fi
+          echo "Found merged pull request(s):"
+          echo "$merged_prs" | jq -r '.[] | "  #\(.number) \(.title)"'
+
       # Grade that the learner actually changed the personas/roles doc in the merged
       # pull request, rather than only that the file exists (it ships with the starter repo).
       - name: Check the personas and roles doc was updated in this pull request
@@ -100,6 +124,8 @@ jobs:
           vars: |
             step_number: 3
             results_table:
+              - description: "Checked the personas and roles update was merged through a pull request"
+                passed: ${{ steps.check-merged-pr.outcome == 'success' }}
               - description: "Checked the personas and roles doc was updated in your pull request"
                 passed: ${{ steps.check-personas-updated.outcome == 'success' }}
 


### PR DESCRIPTION
## Why

In Step 3, the exercise issue was closing before any pull request was reviewed or merged. The Step 3 grading workflow triggers on any `push` to `main` touching `docs/**`. When the personas/roles change reached `main` via a direct commit (for example, when the Copilot Cloud Agent commits straight to `main` instead of opening a pull request), the "personas doc changed" check passed and the exercise finished immediately, closing the exercise issue prematurely.

This was reproduced in a learner copy of the repo: the exercise issue closed seconds after the personas issue was created, triggered by a single-parent commit pushed directly to `main` with no associated PR.

## Approach

Add a guard step to `.github/workflows/3-last-step.yml` that confirms the pushed change is associated with a merged pull request before the exercise can complete:

- New step "Verify the update arrived via a merged pull request" queries the `commits/{sha}/pulls` API for the pushed head commit and requires at least one associated PR with `merged_at` set.
- Direct commits to `main` return no associated PR, so the step fails with actionable feedback and the grading job fails, which prevents `finish_exercise` from running. The exercise issue stays open until the PR is actually merged.
- A genuine merge (merge commit or squash) returns the PR, so the guard passes.
- Added the new check to the step results table and granted `pull-requests: read` permission.

## Notes

- This intentionally keeps the existing push-to-`main` trigger (previously chosen to avoid Actions approval prompts) and only gates completion on a real merge.
- Verified against the affected repo that the API cleanly distinguishes a merged PR push (returns the PR) from a direct commit (returns an empty list). YAML validated.
