### PR TITLE
Fix Step 1 workflow activation

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -63,9 +63,9 @@ jobs:
 
       - name: Reset exercise workflows and enable Step 1
         run: |
-          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/2-step.yml/disable"
-          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/3-last-step.yml/disable"
-          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/1-step.yml/enable"
-          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/0-start-exercise.yml/disable"
+          gh workflow disable "2-step.yml"
+          gh workflow disable "3-last-step.yml"
+          gh workflow enable "1-step.yml"
+          gh workflow disable "0-start-exercise.yml"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -66,5 +66,6 @@ jobs:
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/2-step.yml/disable"
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/3-last-step.yml/disable"
           gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/1-step.yml/enable"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/0-start-exercise.yml/disable"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -61,7 +61,10 @@ jobs:
           issue-number: ${{ env.ISSUE_NUMBER }}
           file: exercise-toolkit/markdown-templates/step-feedback/watching-for-progress.md
 
-      - name: Enable Step 1
-        run: gh workflow enable "Step 1"
+      - name: Reset exercise workflows and enable Step 1
+        run: |
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/2-step.yml/disable"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/3-last-step.yml/disable"
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/actions/workflows/1-step.yml/enable"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -61,12 +61,7 @@ jobs:
           issue-number: ${{ env.ISSUE_NUMBER }}
           file: exercise-toolkit/markdown-templates/step-feedback/watching-for-progress.md
 
-      - name: Reset exercise workflows and enable Step 1
-        run: |
-          gh workflow disable "Step 1"
-          gh workflow disable "Step 2"
-          gh workflow disable "Step 3"
-          gh workflow disable "${{ github.workflow }}"
-          gh workflow enable "Step 1"
+      - name: Enable Step 1
+        run: gh workflow enable "Step 1"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The exercise setup fails after the toolkit disables all step workflows because display-name lookup does not resolve an already-disabled workflow reliably.

Keep using the `gh workflow` client, but select workflows by filename. Step 0 explicitly disables Steps 2 and 3, enables Step 1, and then disables itself after the handoff.