### PR TITLE
Avoid disabling inactive Step 0 workflow

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -61,9 +61,8 @@ jobs:
           issue-number: ${{ env.ISSUE_NUMBER }}
           file: exercise-toolkit/markdown-templates/step-feedback/watching-for-progress.md
 
-      - name: Reset exercise workflows and enable Step 1
-        run: |
-          gh workflow enable "1-step.yml"
-          gh workflow disable "0-start-exercise.yml"
+      - name: Enable Step 1
+        # The start_exercise job disables every exercise workflow before this job runs.
+        run: gh workflow enable "1-step.yml"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Step 0 handoff still fails because the reusable `start_exercise` job has already disabled every exercise workflow, and `gh workflow disable` returns HTTP 403 when Step 0 is inactive.

Rely on the completed toolkit reset for Steps 0, 2, and 3, then use the `gh workflow` client only to enable Step 1 by filename.